### PR TITLE
Corrected queries

### DIFF
--- a/db/db.py
+++ b/db/db.py
@@ -78,30 +78,30 @@ db_test = MySQL()
 nb = Notebook(db=db_test)
 nb.connect_db()
 
-num_req = 100
+num_req = 20000
 
 ##############################################
 
-# db_test.execute(query='insert into user (name) values ("Fet")')
-# db_test.execute(query='insert into book (name,user_id) values ("book1", 1)')
-# for i in range(1,10):
-# 	db_test.execute(query='insert into book_field (field_name, field_type, book_id) values ("field%s","txt",1)'%i)
-# for record in range(2000):
-# 	for i in range(1,10):
-# 		db_test.execute(query='''
+#db_test.execute(query='insert into user (name) values ("Fet")')
+#db_test.execute(query='insert into book (name,user_id) values ("book1", 1)')
+#for i in range(1,10):
+#	db_test.execute(query='insert into book_field (field_name, field_type, book_id) values ("field%s","txt",1)'%i)
+#for record in range(2000):
+#	for i in range(1,10):
+#		db_test.execute(query='''
 # 							insert into book_record
 # 							(record_id, field_id, value_num, value_txt)
 # 							values
 # 							(%(record)d, %(i)d, %(i)d, "field%(i)s")
 # 							''' % {'record': record, 'i': i})
-#
-# db_test.commit()
+
+#db_test.commit()
 
 start_a = time.perf_counter()
 all_types = db_test.execute(query='SELECT * FROM book_field')
 
 for i in range(num_req):
-	r = db_test.execute(query='SELECT * FROM book_record WHERE value_txt="field5"')
+	db_test.execute(query='SELECT id, record_id, field_id FROM book_record WHERE value_txt="field5"')
 
 fin_a = time.perf_counter() - start_a
 print('---> only select', fin_a)
@@ -113,10 +113,10 @@ start_b = time.perf_counter()
 for i in range(num_req):
 
 	QUERY_SELECT_JOIN = """
-	SELECT book_record.id, book_record.record_id, book_record.field_id, book_field.field_name
+	SELECT book_record.id, book_record.record_id, book_field.field_name
 	FROM book_record
 	INNER JOIN book_field
-	ON book_record.field_id=book_field.id and field_name="field5";
+	ON book_record.field_id=book_field.id and book_record.value_txt="field5";
 	"""
 
 	db_test.execute(query=QUERY_SELECT_JOIN)
@@ -127,4 +127,3 @@ print('---> with join', fin_b)
 print('---> diff', fin_b / fin_a)
 
 nb.close_db()
-


### PR DESCRIPTION
After updating queries for same fields.

2000
---> only select 26.103842410026118
---> with join 27.319715298945084
---> diff 1.0465783109559368

20000
---> only select 272.22438701801
---> with join 268.65499714016914
---> diff 0.9868880598210155

And it with `join` is still faster.
I suppose, I will be better if you read something about query optimization just to get more information.

What is my point why query with join is faster.
When we make filtering `... ON book_record.field_id=book_field.id and book_record.value_txt="field5";`, operation `book_record.field_id=book_field.id` cut off many rows from joined tables, and after it filter by second part of request `book_record.value_txt="field5"` thru remaining rows.
Query with NO join has to search thru all rows.


